### PR TITLE
Ignore err until exitValue != 0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "com.modmountain.sbt"
 
 name := "sbt-autoprefixer"
 
-version := "0.2.1"
+version := "0.2.2"
 
 scalaVersion := "2.10.6"
 

--- a/src/main/scala/com/modmountain/sbt/autoprefixer/SbtAutoprefixer.scala
+++ b/src/main/scala/com/modmountain/sbt/autoprefixer/SbtAutoprefixer.scala
@@ -80,7 +80,7 @@ object SbtAutoprefixer extends AutoPlugin {
       (error: String) => err.append(error + "\n"))
 
     val process = command.run(capturer)
-    if (process.exitValue != 0 || err.nonEmpty) {
+    if (process.exitValue != 0) {
       throw new RuntimeException(err.toString)
     }
   }


### PR DESCRIPTION
postcss-cli's behavior has changed and it now outputs "Finished <filename>" to stderr. So I choose to ignore err until an exitValue that differs from 0. 